### PR TITLE
fix: run flux envsubst per-document to avoid literal ${...} text breaking builds

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -6,6 +6,7 @@ on:
     paths:
     - '.github/workflows/test-action.yaml'
     - 'action.yml'
+    - 'ci/negative-test-data/*'
     - 'ci/test-data/*'
     - 'ci/validation/*'
     - 'scripts/*.sh'
@@ -27,7 +28,7 @@ jobs:
       uses: ./
       with:
         # yamllint disable rule:line-length
-        files: '["ci/test-data/test-package/nginx-deployment.yaml", "ci/test-data/test-package/nginx-ingress.yaml", "ci/test-data/test-package/nginx-service.yaml", "ci/test-data/kustomization.yaml"]'
+        files: '["ci/test-data/test-package/nginx-deployment.yaml", "ci/test-data/test-package/nginx-ingress.yaml", "ci/test-data/test-package/nginx-service.yaml", "ci/test-data/substitute-disabled/configmap-literal.yaml", "ci/test-data/substitute-disabled/deployment-substituted.yaml", "ci/test-data/kustomization.yaml"]'
         pkg-include: '["ci/test-data/*"]'
         pkg-exclude: '[]'
         env-file: 'ci/validation/.env'
@@ -45,8 +46,34 @@ jobs:
     - name: Test - Explicit List of Kustomizations
       uses: ./
       with:
-        files: '["ci/test-data/test-package/kustomization.yaml", "ci/test-data/kustomization.yaml"]'
+        # yamllint disable-line rule:line-length
+        files: '["ci/test-data/test-package/kustomization.yaml", "ci/test-data/substitute-disabled/kustomization.yaml", "ci/test-data/kustomization.yaml"]'
         pkg-include: '["ci/test-data/*"]'
         pkg-exclude: '[]'
         env-file: 'ci/validation/.env'
         debug: 'false'
+
+    # `ci/test-data/substitute-disabled/configmap-literal.yaml` (validated above) is annotated
+    # `kustomize.toolkit.fluxcd.io/substitute: disabled` and ships literal `${arr[@]}`-shaped text
+    # that would make `flux envsubst` fail outright if it weren't skipped for that resource — so
+    # the passing runs above already prove the annotation prevents that crash, and that the
+    # sibling `deployment-substituted.yaml` (no annotation) still gets real `${VAR}` substitution
+    # in the same build. This step is the negative control: it proves kubeconform still validates
+    # an annotated resource's schema rather than the annotation silently skipping validation too.
+    - name: Test - Annotated resource with invalid schema is still caught by kubeconform
+      id: negative-substitute-disabled
+      continue-on-error: true
+      uses: ./
+      with:
+        files: '["ci/negative-test-data/substitute-disabled-invalid/kustomization.yaml"]'
+        pkg-include: '["ci/negative-test-data/*"]'
+        pkg-exclude: '[]'
+        debug: 'false'
+
+    - name: Assert - previous step failed as expected
+      if: steps.negative-substitute-disabled.outcome != 'failure'
+      run: |
+        echo "::error::Expected 'Annotated resource with invalid schema' step to fail (kubeconform"
+        echo "::error::should still validate substitute:disabled resources), but its outcome was:"
+        echo "::error::'${{ steps.negative-substitute-disabled.outcome }}'"
+        exit 1

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ repos:
 ## Configuration Options
 
 | Parameter | Description | Default | Example |
-|-----------|-------------|---------|---------|
+| ----------- | ------------- | --------- | --------- |
 | `files` | JSON array of file paths (Action only) | `[]` | `["apps/media/plex/kustomization.yaml"]` |
 | `pkg-include` | Glob patterns for including directories | `["."]` | `["apps/*"]` |
 | `pkg-exclude` | Glob patterns for excluding directories | `[]` | `["test/*"]` |
@@ -230,6 +230,26 @@ spec:
   replicas: 3
 ```
 
+**Excluding a resource from substitution**:
+
+`flux envsubst` is a plain-text pass over the whole document — it can't tell a real `${VAR_NAME}` placeholder from literal `${...}`-shaped text that happens to live in a field (e.g. a CRD schema description, or a ConfigMap shipping a script that legitimately uses `${arr[@]}`-style shell expansion). Substitution is applied per-resource, so annotate any resource that must keep its `${...}` text literal with `kustomize.toolkit.fluxcd.io/substitute: disabled` — the same annotation [Flux's kustomize-controller honors](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution) to opt a resource out of postBuild substitution:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: entrypoint-script
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+data:
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+    arr=("a" "b" "c")
+    echo "${arr[@]}"  # left untouched, would otherwise break envsubst
+```
+
+Resources without the annotation are substituted as normal, and kubeconform still validates every resource regardless of the annotation.
+
 ### Repository-wide Validation
 
 Pass `.` as the file argument to validate all `kustomization.yaml` files recursively:
@@ -250,6 +270,7 @@ The script requires these tools to be available. While they are automatically in
 - `kubeconform` - Kubernetes manifest validation
 - `kustomize` - Kubernetes native configuration management
 - `flux` - GitOps toolkit CLI
+- `yq` - YAML processor (used to split multi-document build output for per-document postBuild substitution)
 - `jq` - JSON processor
 - `wget` - File downloader
 

--- a/action.yml
+++ b/action.yml
@@ -181,8 +181,8 @@ runs:
       mapfile -t FILES < <(echo '${{ steps.final-list.outputs.kustomizations }}' | jq -r '.[]')
       ${{ github.action_path }}/scripts/validate-k8s.sh \
         --github-mode \
-        --pkg-include \"${PKG_INCLUDES}\" \
-        --pkg-exclude \"${PKG_EXCLUDES}\" \
+        --pkg-include "${PKG_INCLUDES}" \
+        --pkg-exclude "${PKG_EXCLUDES}" \
         --kubeconform-flags "${KUBECONFORM_FLAGS}" \
         --kustomize-flags "${KUSTOMIZE_FLAGS}" \
         $( [[ -n "${ENV_FILE}" ]] && echo "--env-file ${ENV_FILE}" ) \

--- a/action.yml
+++ b/action.yml
@@ -164,6 +164,8 @@ runs:
       KUSTOMIZE_VERSION: "v5.8.1"
       # renovate: datasource=github-releases depName=fluxcd/flux2
       FLUX_VERSION: "v2.9.3"
+      # renovate: datasource=github-releases depName=mikefarah/yq
+      YQ_VERSION: "v4.53.3"
       # INPUTS
       BASE_KUSTOMIZATION_FILE: ${{ inputs.base-kustomization-file }}
       DEBUG_ENABLED: ${{ inputs.debug }}

--- a/ci/negative-test-data/substitute-disabled-invalid/deployment-invalid.yaml
+++ b/ci/negative-test-data/substitute-disabled-invalid/deployment-invalid.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: invalid-schema
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+spec:
+  replicas: "not-a-number"
+  selector:
+    matchLabels:
+      app: invalid-schema
+  template:
+    metadata:
+      labels:
+        app: invalid-schema
+    spec:
+      containers:
+      - name: app
+        image: nginx
+        command: ["sh", "-c", "echo ${arr[@]}"]

--- a/ci/negative-test-data/substitute-disabled-invalid/kustomization.yaml
+++ b/ci/negative-test-data/substitute-disabled-invalid/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment-invalid.yaml

--- a/ci/test-data/substitute-disabled/configmap-literal.yaml
+++ b/ci/test-data/substitute-disabled/configmap-literal.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: literal-script
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+data:
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+    arr=("a" "b" "c")
+    echo "${arr[@]}"
+    echo "not a real flux var: ${NAMESPACE}"

--- a/ci/test-data/substitute-disabled/deployment-substituted.yaml
+++ b/ci/test-data/substitute-disabled/deployment-substituted.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: substituted
+  namespace: ${NAMESPACE}
+spec:
+  replicas: ${REPLICA_COUNT}
+  selector:
+    matchLabels:
+      app: substituted
+  template:
+    metadata:
+      labels:
+        app: substituted
+    spec:
+      containers:
+      - name: app
+        image: nginx
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"

--- a/ci/test-data/substitute-disabled/kustomization.yaml
+++ b/ci/test-data/substitute-disabled/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- configmap-literal.yaml
+- deployment-substituted.yaml

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -30,6 +30,10 @@ install_from_github_release_asset() {
   local asset_pattern="$3"
   local dest_dir="$4"
   local executable="$5"
+  # Name of the extracted binary inside the tarball, when it differs from the
+  # final installed executable name (e.g. yq's asset extracts to
+  # `yq_linux_amd64`, not `yq`). Defaults to `executable`.
+  local extracted_name="${6:-$executable}"
   local url
   local asset
   if [[ -f "${dest_dir}/${executable}" ]]; then
@@ -45,7 +49,7 @@ install_from_github_release_asset() {
   curl ${CURL_FLAGS} -o "${TEMP_DIR}/${asset}" "${url}" 2>&1 | sed -E 's|^|    |g'
   cd "${TEMP_DIR}/"
   tar -xzf "${asset}"
-  mv "${executable}" "${dest_dir}/${executable}"
+  mv "${extracted_name}" "${dest_dir}/${executable}"
   chown "${USER}" "${dest_dir}/${executable}"
   chmod 755 "${dest_dir}/${executable}"
   echo "-> ${dest_dir}/${executable}"
@@ -65,6 +69,9 @@ install_dependencies() {
   echo
   echo "Installing kustomize..."
   install_from_github_release_asset kubernetes-sigs/kustomize "kustomize/${KUSTOMIZE_VERSION:-".*"}" 'kustomize_.*_linux_amd64\.tar\.gz' "${dest_dir}" kustomize | sed -E 's|^|    |g'
+  echo
+  echo "Installing yq..."
+  install_from_github_release_asset mikefarah/yq "${YQ_VERSION:-".*"}" 'yq_linux_amd64\.tar\.gz' "${dest_dir}" yq yq_linux_amd64 | sed -E 's|^|    |g'
 }
 
 show_versions() {
@@ -72,6 +79,7 @@ show_versions() {
   kustomize version | sed -E 's|^|    |g'
   kubeconform -v | sed -E 's|^|    |g'
   flux -v | sed -E 's|^|    |g'
+  yq --version | sed -E 's|^|    |g'
 }
 
 main() {

--- a/scripts/validate-post.sh
+++ b/scripts/validate-post.sh
@@ -80,6 +80,39 @@ aggregate_results() {
   cat "${results_dir}/aggregated.json"
 }
 
+FLUX_SUBSTITUTE_ANNOTATION='kustomize.toolkit.fluxcd.io/substitute'
+
+# Splits a multi-document YAML stream and runs `flux envsubst` on every document except
+# those annotated `kustomize.toolkit.fluxcd.io/substitute: disabled` — mirroring how the
+# real Flux kustomize-controller performs postBuild substitution per-resource rather than
+# on the raw build output as a whole.
+#
+# `flux envsubst` itself has no annotation awareness: it is a plain-text substitution pass,
+# so piping an annotated document (e.g. a ConfigMap shipping a bash script) through it
+# anyway corrupts or outright breaks on bash-specific parameter-expansion syntax that isn't
+# valid Flux postBuild substitution syntax but is valid, deliberately-preserved shell (array
+# subscripts `${arr[@]}`, nested expansions `${a%"${b}"}`, etc.).
+substitute_build() {
+  local input_file=$1
+  local split_dir
+  split_dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf ${split_dir}" RETURN
+
+  yq -s "\"${split_dir}/doc_\" + (\$index | tostring)" "$input_file" >/dev/null
+
+  local doc substitute_disabled
+  for doc in $(find "${split_dir}" -name 'doc_*.yml' | sort -V); do
+    substitute_disabled=$(yq ".metadata.annotations.\"${FLUX_SUBSTITUTE_ANNOTATION}\" // \"\"" "$doc")
+    if [[ "$substitute_disabled" == "disabled" ]]; then
+      cat "$doc"
+    else
+      flux envsubst < "$doc"
+    fi
+    echo "---"
+  done
+}
+
 validate_post() {
   local dirs=("$@")
 
@@ -126,7 +159,9 @@ validate_post() {
     local output_file="${results_dir}/output_${i}.json"
 
     $DEBUG && >&2 echo "${pkg_dir}: building kustomization..."
-    kustomize build . "$KUSTOMIZE_FLAGS" | flux envsubst > "${built_kustomization}"
+    local built_raw="${temp_dir}/build_raw_${i}.yaml"
+    kustomize build . "$KUSTOMIZE_FLAGS" > "${built_raw}"
+    substitute_build "${built_raw}" > "${built_kustomization}"
     $DEBUG && >&2 echo "${pkg_dir}: validating built kustomization..."
     if ! "${SCRIPT_DIR}"/run-kubeconform.sh -c "${KUBECONFORM_FLAGS} -summary" -f json -o "${result_file}" "${built_kustomization}"; then
       $DEBUG && >&2 echo "${pkg_dir}: kubeconform failed!"


### PR DESCRIPTION
## Summary

Fixes #95. Part of ppat/homelab-ops-kubernetes-apps#3416.

`flux envsubst` scans an entire multi-document build output as one blob of
text, so it has no way to tell a genuine Flux postBuild `${VAR}` reference
apart from literal `${...}`-shaped text that legitimately belongs in the
content (a vendored CRD's schema `description:` prose, an embedded
strategic-merge patch string, a ConfigMap shipping a shell script that uses
`${arr[@]}`-style array expansion, etc). One offending resource anywhere in
a package's build output breaks substitution — and therefore validation —
for every resource in that package.

This splits the built multi-document YAML on document boundaries and runs
`flux envsubst` per-document instead of once over the whole stream, and
skips substitution entirely (while still running kubeconform against it)
for any document annotated `kustomize.toolkit.fluxcd.io/substitute:
disabled` — the same annotation [Flux's kustomize-controller honors](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution)
to exclude a resource from postBuild substitution, and already used in the
apps repo for exactly this reason (see `ci/test/apps-ai/pre-requisites/openclaw-config.yaml`
there). The same annotation-based approach is already validated in a real
production instance in `homelab-ops-kubernetes-experiments`
([PR #203](https://github.com/ppat/homelab-ops-kubernetes-experiments/pull/203),
a cloud-init `${VERSION_CODENAME}` breaking strict-mode Flux substitution).

The `substitute_build` split/skip mechanism itself was prototyped and
empirically verified against the real 133-document build output of
`ci/test/apps-ai/pre-requisites` in a prior pass — see
ppat/homelab-ops-kubernetes-apps#3416
([comment](https://github.com/ppat/homelab-ops-kubernetes-apps/issues/3416#issuecomment-5161160743)).
This PR builds on that prototype essentially unchanged and closes the two
gaps left open:

- **Missing dependency**: `substitute_build` uses `yq`, but
  `scripts/install-dependencies.sh` didn't install it — it "worked" only
  because `ubuntu-latest` runners happen to ship `yq` preinstalled, which
  is undocumented and not guaranteed on other runners or for local
  pre-commit users. `yq` is now installed the same way as the other three
  tools (pinned via a `# renovate: datasource=github-releases` comment,
  auto-managed by the existing generic regex customManager), and added to
  the README's `## Dependencies` list.
- **No test coverage**: nothing exercised the `substitute: disabled`
  annotation path. Added fixtures (see below) proving, in CI, that a
  document with literal envsubst-breaking text survives when annotated,
  that an adjacent unannotated document in the same build still gets real
  substitution, and — as a negative control, per this run's "test controls
  in the failing direction" norm — that kubeconform still validates an
  annotated document's schema rather than the annotation silently skipping
  validation too.

## What changed

- `scripts/install-dependencies.sh`: installs `yq` (pinned `YQ_VERSION`,
  Renovate-managed like the other tools). `install_from_github_release_asset`
  gained an optional 6th `extracted_name` arg since yq's tarball extracts to
  `yq_linux_amd64`, not `yq`.
- `action.yml`: pins `YQ_VERSION`.
- `README.md`: documents `yq` as a dependency, and adds a
  "Excluding a resource from substitution" subsection explaining the
  `substitute: disabled` annotation escape hatch.
- `ci/test-data/substitute-disabled/`: happy-path fixture — a ConfigMap
  annotated `substitute: disabled` containing literal `${arr[@]}` (which
  reliably makes `flux envsubst` fail with "missing closing brace" if not
  skipped — verified locally), alongside an unannotated Deployment using
  the existing `${NAMESPACE}`/`${REPLICA_COUNT}` vars from
  `ci/validation/.env`. Wired into all three existing `test-action.yaml`
  discovery modes (seed, discover-all, explicit list).
- `ci/negative-test-data/substitute-disabled-invalid/`: negative-control
  fixture — an annotated Deployment with `spec.replicas: "not-a-number"`
  (an invalid type kubeconform's strict schema check reliably flags) plus
  the same literal `${arr[@]}` text, run via a dedicated
  `continue-on-error: true` step in `test-action.yaml` with a follow-up
  assertion step that fails the job if that step *didn't* fail — proving
  kubeconform still runs against `substitute: disabled` documents. Lives
  outside `ci/test-data/` (a sibling directory, not a nested one — path
  filters here do prefix matching) so it's never picked up by the
  happy-path steps' `pkg-include: '["ci/test-data/*"]'`.
- `.github/workflows/test-action.yaml`: the fixture wiring above, plus
  `ci/negative-test-data/*` added to the `pull_request.paths` trigger.

## Also fixed: `pkg-include`/`pkg-exclude` were silent no-ops in the action

Wiring the negative-control fixture into `test-action.yaml`'s "Discover
all" step (`pkg-include: '["ci/test-data/*"]'`) surfaced a second,
unrelated pre-existing bug: `action.yml`'s "Run validation" step built the
command line as `--pkg-include \"${PKG_INCLUDES}\"` — the backslash-escaped
quotes are literal `"` characters, not real shell quoting, so
`validate-k8s.sh` received the JSON array wrapped in an *extra* pair of
literal quote characters (`"["ci/test-data/*"]"` instead of
`["ci/test-data/*"]`). `jq -r '.[]'` can't parse that and errors out
silently (the error isn't fatal under `set -e` because it happens inside a
`mapfile < <(...)` process substitution), leaving `INCLUDES`/`EXCLUDES`
empty — which `validate-k8s.sh` then treats as its own "include everything"
default. Net effect: `pkg-include`/`pkg-exclude` have been silent no-ops in
the GitHub Action interface for any repo with more than one candidate
package directory, since this line was introduced — it just never showed
up because `ci/test-data/*` was previously the only top-level dir with a
`kustomization.yaml` in this repo's own fixtures, so "include everything"
and "include `ci/test-data/*`" were indistinguishable until this PR added
a second one (`ci/negative-test-data/`). Fixed with real quoting
(`--pkg-include "${PKG_INCLUDES}"`); pre-commit's `validate-k8s` hook was
never affected (it invokes `validate-k8s.sh`'s argv directly, no shell
re-quoting involved). Confirmed locally both before (negative fixture
wrongly included) and after (correctly excluded) the fix — see Verification
below.

## Verification

- `pre-commit run --all-files` passes locally, including the repo's own
  `validate-k8s` local hook running the real `substitute_build` prototype
  against `ci/test-data/*`.
- Manually confirmed (before wiring the fixture into CI):
  - `flux envsubst` on the literal `${arr[@]}` text fails with `missing
    closing brace` when *not* skipped (i.e. removing the annotation from
    the fixture reproduces the original bug and breaks the whole run) —
    confirms the fixture is a real regression guard, not a no-op.
  - Piping the split output of `substitute_build` back through `yq`/`cat`
    shows the annotated document survives byte-for-byte (including the
    literal `${arr[@]}` and `${NAMESPACE}` text), while the adjacent
    unannotated Deployment gets real substitution (`namespace:
    test-namespace`, `replicas: 2`).
  - `kubeconform` (via `scripts/run-kubeconform.sh`) flags the negative
    fixture's `spec.replicas: "not-a-number"` as invalid and exits
    non-zero.
- zizmor run locally against `.github/workflows/` and `action.yml`: no new
  findings versus `origin/main` (the one pre-existing `excessive-permissions`
  warning on `test-action.yaml` predates this change).

## Test plan

- [x] `pre-commit run --all-files` green locally
- [ ] This repo's own CI (`lint.yaml`, `test-action.yaml`) green on the PR
