### PR TITLE
chore(github-actions): update ppat/github-workflows (v4.4.0 -> v5.0.1)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   detect-changes:
-    uses: ppat/github-workflows/.github/workflows/detect-changed-files.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/detect-changed-files.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       # yamllint disable-line rule:indentation
       files_yaml: |
@@ -41,7 +41,7 @@ jobs:
 
   commit-messages:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: ppat/github-workflows/.github/workflows/lint-commit-messages.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-commit-messages.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref }}
       fetch_depth: ${{ github.event.pull_request.commits || 0 }}
@@ -51,7 +51,7 @@ jobs:
   github-actions:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-github-actions.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-github-actions.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).actions_all_changed_files }}
@@ -59,20 +59,20 @@ jobs:
   markdown:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).markdown_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).markdown_all_changed_files }}
 
   pre-commit:
-    uses: ppat/github-workflows/.github/workflows/lint-pre-commit.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-pre-commit.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
 
   renovate-config-check:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).renovate_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-renovate-config-check.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-renovate-config-check.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).renovate_all_changed_files }}
@@ -80,7 +80,7 @@ jobs:
   shellcheck:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).shellscripts_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).shellscripts_all_changed_files }}
@@ -88,7 +88,7 @@ jobs:
   yaml:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).yaml_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).yaml_all_changed_files }}
@@ -96,6 +96,6 @@ jobs:
   zizmor:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).zizmor_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-zizmor.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-zizmor.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: ppat/github-workflows/.github/workflows/release-please.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/release-please.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     secrets:
       app_id: ${{ secrets.HOMELAB_BOT_APP_ID }}
       app_private_key: ${{ secrets.HOMELAB_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   renovate:
-    uses: ppat/github-workflows/.github/workflows/renovate.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/renovate.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       dry_run: "${{ github.event_name	== 'pull_request' }}"
       git_ref: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Summary

Bumps every `ppat/github-workflows` reference from `v4.4.0` to **`v5.0.1`**
(`667d20d10c8756b11feeab1ee691825ccea8f991`, verified against the `v5.0.1`
tag), preserving this repo's full-SHA + trailing `# vX.Y.Z` comment pin
convention. 11 occurrences bumped across `.github/workflows/lint.yaml` (9),
`release.yaml` (1), `renovate.yaml` (1); confirmed 0 occurrences of the old
`1e8ca1b0…` pin remain.

Supersedes #105 (the Renovate-opened `v4.4.0 -> v5.0.0` PR). Not closing or
modifying it per instruction — Renovate/a maintainer should close it once
this merges.

Per standing instruction for this bump: **no changes to `commitlint.config.js`
/ `scope-enum`, and no bump of the `renovate-presets` pin** (this repo's
`.github/renovate.json` still extends `ppat/renovate-presets#v0.2.1`,
untouched).

## Input-compatibility check (v4.4.0 → v5.0.1)

Diffed `workflow_call.inputs` for all 11 called workflows between the two
tags in `ppat/github-workflows`. Every change is additive (new optional
inputs, all with defaults, or env-var version bumps inside the callee) —
**no renamed or removed inputs, no new required inputs, no changed secret
names**. Nothing here required a call-site change beyond the ref bump:

| Workflow | Change |
|---|---|
| `detect-changed-files.yaml` | none |
| `lint-commit-messages.yaml` | none (internal quoting fixes only) |
| `lint-github-actions.yaml` | `ACTIONLINT_VERSION` v1.7.4→v1.7.12; new `SHELLCHECK_VERSION` v0.11.0 env pin |
| `lint-markdown.yaml` | none (internal `# shellcheck disable=` additions only) |
| `lint-pre-commit.yaml` | `PRECOMMIT_VERSION` v4.6.1→v4.6.2, `UV_VERSION` 0.12.3→0.12.5 |
| `lint-renovate-config-check.yaml` | `RENOVATE_VERSION` 44.14.12→44.30.4 |
| `lint-shellcheck.yaml` | file-selection rewrite (see below); no input change |
| `lint-yaml.yaml` | `UV_VERSION` 0.12.3→0.12.5 |
| `lint-zizmor.yaml` | +4 new **optional** inputs (`advisory_only`, `min_confidence`, `min_severity`, `persona`), all default to current behaviour; this repo's call sets none of them |
| `release-please.yaml` | +2 new **optional** inputs (`dry_run`, `verbose`, no default); internals swapped from `googleapis/release-please-action` to a direct CLI invocation, but `secrets.app_id`/`secrets.app_private_key` (both still `required: true`) and the `release-please-config.json` / `.release-please-manifest.json` filenames are unchanged, so this repo's `release.yaml` caller needed no edits |
| `renovate.yaml` | none observable at the call-site level (internal `renovatebot/github-action` bump, `repositories:` input added to token step) |

## actionlint/shellcheck gate — reproduced locally, zero findings

**The premise that this bump would surface shellcheck findings in this repo
did not hold — this repo has zero findings, unlike the three sibling repos.**
Installed actionlint v1.7.12 (via `mise install aqua:rhysd/actionlint@1.7.12`)
and shellcheck v0.11.0 (already present, matching the pin), then ran the
exact commands `lint-github-actions.yaml`'s `github-actions` job runs:

```
$ actionlint -shellcheck shellcheck            # "ALL" branch (auto-discovery)
Found 0 errors in 4 files
```

Sanity-checked the shellcheck integration itself is live (not silently
disabled) by injecting a deliberate `echo $VAR` (SC2086) into
`test-action.yaml`'s one `run:` block — actionlint caught it immediately,
then the injection was reverted. The repo's real workflow files
(`lint.yaml`, `release.yaml`, `renovate.yaml` have no `run:` steps at all;
`test-action.yaml` has exactly one, already quote-clean) simply have no
`run:` content for shellcheck to flag.

Also reproduced `lint-shellcheck.yaml`'s direct-shellcheck gate against
`scripts/*.sh` with `--rcfile .shellcheckrc`: all 6 scripts `PASS`, 0 failed.

**Before/after linted file set for `lint-shellcheck.yaml`'s new
shebang/extension-based selector** (replacing the old executable-bit scan):
identical — `{fetch-schemas.sh, install-dependencies.sh, run-kubeconform.sh,
validate-k8s.sh, validate-post.sh, validate-pre.sh}` in both, since all six
scripts are both executable *and* carry a `.sh` extension. No coverage
regression.

**No workflow-file or `scripts/*.sh` changes were made** — there was nothing
to fix or suppress.

## `action.yml` — findings, and a correction to this bump's stated scope

This repo is itself a composite action consumed by `apps`, `clusters` and
`experiments`, so `action.yml` got the most scrutiny (Munger's-inversion
lens: a quoting change there breaks three other repos' CI at runtime, not
just this one's at lint time).

**Empirically, `actionlint`'s `-shellcheck` integration never reaches
`action.yml`, in this repo or in general** — this contradicts the brief this
work started from, so flagging it explicitly rather than silently reporting
"clean" without the caveat:

- Passing `action.yml` as an explicit CLI argument makes actionlint parse it
  as a *workflow* file (it has no separate "composite action" file mode for
  direct arguments) — it fails immediately on `syntax-check` (`"jobs" section
  is missing`, `unexpected key "description"`, etc.), never reaching the
  shellcheck rule.
- Auto-discovery mode (what the `ALL` branch actually runs, and what
  `lint-github-actions.yaml` uses on non-PR triggers) only collects
  `.github/workflows/*.yaml` — `action.yml` is not among the 4 files
  collected, confirmed with `-verbose`.
- Proved this isn't just "clean" by injecting an obvious `echo $PROBE_VAR`
  (SC2086) directly into `action.yml`'s `run:` block and re-running the exact
  auto-discovery command: 0 errors, unchanged. Reverted immediately after.
- What actionlint *does* do for `action.yml`: local-action schema
  introspection — when a workflow (`test-action.yaml`) references `uses: ./`,
  actionlint validates the caller's `with:` keys against `action.yml`'s
  declared `inputs:`. Confirmed this works (an injected undeclared input was
  correctly flagged 4 times, once per `uses: ./` step), then reverted. This
  is a schema check, not a shellcheck pass.
- Separately, the PR-triggered path can't reach it either: `lint.yaml`'s
  `actions` change-detection filter is `.github/workflows/**` only, so even
  a PR that edits `action.yml` never adds it to the file list the
  `github-actions` job lints.

Net: **`action.yml`'s `run:` blocks are not exercised by this gate today,
before or after v5.0.1** — the version bump does not change that in either
direction, so nothing needed fixing or suppressing there for CI purposes.
For due diligence I read through `action.yml`'s `run:` blocks anyway: the
only unquoted-variable patterns are `>> $GITHUB_OUTPUT` (redirection target,
argv-safe) and the trailing `$( [[ ... ]] && echo "--flag ${VAR}" )`
constructs in the validation step, whose word-splitting into two `argv`
tokens is the intended behaviour (equivalent to the brief's SC2046
"provably safe" carve-out) — left untouched, no source change made.

Checked whether v5 interacts with `action.yml`'s `actions/cache@…v6.1.0`
usage: it doesn't. `git diff v4.4.0 v5.0.1` in `github-workflows` touches
only CI-tooling workflow files (`actionlint`/`shellcheck`/
`renovate-config-validator`/`zizmor`/`release-please`); there is no
`actions/` directory in that repo at all, and nothing in the diff mentions
`actions/cache`.

## `renovate-config-validator` 44.14.12 → 44.30.4

Ran `.github/renovate.json` through the pinned target version directly
(`npx -p renovate@44.30.4 renovate-config-validator .github/renovate.json`):
`Config validated successfully against 1 file(s)`. No `.github/renovate/`
directory exists, so there's nothing else for that job to validate.

## README / release-please `extra-files` mechanism

Not touched. No `x-release-please-version` annotations or
`release-please-config.json` / `.release-please-manifest.json` content were
modified — this PR only changes `.github/workflows/*.yaml` ref pins.

## Verification run

- `pre-commit run --files .github/workflows/{lint,release,renovate}.yaml`:
  all hooks pass (`yamllint --strict`, the local `validate-k8s` hook against
  the changed YAML, commitlint on the commit message).
- `python3 -c 'yaml.safe_load(...)'` on all three changed files: parses
  clean.

## CI

Will watch to green after opening. `test-action.yaml` (the direct
self-test of the composite action) is path-gated on
`.github/workflows/test-action.yaml`, `action.yml`, `ci/negative-test-data/*`,
`ci/test-data/*`, `ci/validation/*`, `scripts/*.sh` — none of which this PR
touches, so it will not run automatically on this PR. Will `gh workflow run`
it on this branch via `workflow_dispatch` and report which run verified the
composite action still works.
